### PR TITLE
fix(main): Correct username prefix removal logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -284,7 +284,7 @@ def _get_owners(client, project):
         users = list(filter(filter_users, members))
         if not users:
             logger.debug('No owner is a user for Project %s.', project_name)
-    users = set([user.strip('user:') for user in users])
+    users = set([user.removeprefix('user:') for user in users])
     return list(users)
 
 
@@ -325,3 +325,4 @@ def _get_created_days_ago(project):
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
The `strip()` method was incorrectly used to remove the 'user:' prefix from owner emails. This caused the unintended removal of leading characters from usernames if those characters were also present in the string 'user:'.

This commit replaces `strip()` with `removeprefix()`, ensuring that only the exact 'user:' prefix is stripped from the beginning of the string. This resolves the bug and guarantees the integrity of all usernames in notifications.