### PR TITLE
Feat/add age filter to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Defines the criteria for selecting projects to be analyzed.
 
   * `orgs`: (Required) A list of numeric Google Cloud organization IDs you wish to monitor.
   * `age_minimum_days`: (Required) The minimum age, in days, a project must be to be considered a "zombie".
+  * `age_maximum_days`: (Required) The maximum age, in days, for a project to be considered. This creates a time window for analysis, preventing notifications for very old projects. Set to 0 to disable.
   * `users_regex`: (Optional) A list of regular expressions (regex) to exclude projects owned by certain users.
   * `projects`: (Optional) A list of specific project IDs to ignore during the check.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following roles will be assigned to the bot's service account by Terraform:
 
 ## Prerequisite: Setting Up Billing Data in BigQuery
 
-The tool's ability to report on costs depends on having access to your detailed billing data. This is achieved by exporting your Cloud Billing data to a BigQuery dataset and then creating a specific `VIEW` for the tool to query.
+The tool's ability to report on costs depends on having access to your detailed billing data. This is achieved by exporting your Cloud Billing data to a BigQuery dataset.
 
 ### Step 1: Enable Cloud Billing Export to BigQuery
 
@@ -78,41 +78,13 @@ If you haven't done so already, you need to enable the detailed billing data exp
 
 For detailed instructions, follow the official Google Cloud guide: [Set up Cloud Billing data export to BigQuery](https://cloud.google.com/billing/docs/how-to/export-data-bigquery).
 
-### Step 2: Create the Cost Aggregation View
+### Step 2: Identify the Billing Export Table Name
 
-Once your billing data is exporting, create a BigQuery `VIEW`. A view is a virtual table based on the result of an SQL query. This provides a simplified and efficient way for the bot to get the exact cost data it needs.
+Once your billing data is exporting, locate and copy the full name of the table created by the export process. This is the name you will specify in your `config.yaml`.
 
-1.  Navigate to the **BigQuery** section in the Google Cloud Console.
-2.  Select the project where your billing export is located.
-3.  Open the SQL query editor.
-4.  Paste the query below, making sure to **update the table name in the `FROM` clause** to match your billing export table.
-5.  Click **"Save"** and choose **"Save view"**. Give it the name that you will later specify in your `config.yaml` (e.g., `costs_per_project`).
+The format is typically `project-id.dataset_name.gcp_billing_export_v1_XXXXXX_XXXXXX_XXXXXX`.
 
-**SQL Query to Create the View:**
-
-```sql
-SELECT
-    '<billing-account-name>' AS billing_account_name
-,   billing_account_id
-,   project.id AS project_id
-,   ROUND(SUM(cost), 2) AS cost_generated
-,   currency
-,   DATE_SUB(DATE_TRUNC(current_date, MONTH), INTERVAL 1 MONTH) AS cost_reference_start_date
-FROM
-    `<Your-big-query-table>`
-WHERE
-    project.id IS NOT NULL
-    AND PARSE_DATE("%Y-%m-%d", FORMAT_TIMESTAMP("%Y-%m-%d", usage_start_time))
-          >= DATE_SUB(DATE_TRUNC(current_date, MONTH), INTERVAL 1 MONTH)
-GROUP BY
-    billing_account_name
-,   billing_account_id
-,   project.id
-,   currency
-,   cost_reference_start_date
-```
-
-
+*(Optional) For advanced use cases where you prefer to use a pre-aggregated summary, you can create a BigQuery `VIEW` and point the configuration to it. An example query for creating such a view can be found in the `example-bigquery-billing-costs-view.sql` file.*
 
 ## Configuration
 
@@ -130,10 +102,9 @@ Defines the criteria for selecting projects to be analyzed.
 
   * `orgs`: (Required) A list of numeric Google Cloud organization IDs you wish to monitor.
   * `age_minimum_days`: (Required) The minimum age, in days, a project must be to be considered a "zombie".
-  * `age_maximum_days`: (Required) The maximum age, in days, for a project to be considered. This creates a time window for analysis, preventing notifications for very old projects. Set to 0 to disable.
+  * `age_maximum_days`: (Optional) Defines the time window, in days, for cost calculation (e.g., `180` calculates costs for the last 180 days). Set to `0` to use the default behavior (costs since the beginning of the previous month).
   * `users_regex`: (Optional) A list of regular expressions (regex) to exclude projects owned by certain users.
   * `projects`: (Optional) A list of specific project IDs to ignore during the check.
-
 #### `org_info` section
 
   * `activate`: Set to `true` to enable the bot to fetch and display the full folder path of the project in notifications.
@@ -159,7 +130,7 @@ Points to your billing data source.
 
   * `activate`: Set to `true` to include cost information in notifications.
   * `bigquery_client_project`: The project ID where your BigQuery billing export dataset is located.
-  * `cost_view_full_name`: The full name of the BigQuery view you created (format: `project.dataset.view_name`).
+  * `billing_export_table_name`: (Required if `billing.activate` is `true`) The full name of your BigQuery table containing the detailed billing export data (format: `project.dataset.table_name`).
 
 #### `org_names_mapping` section
 
@@ -201,7 +172,7 @@ Creates human-readable aliases for your numeric organization IDs.
 1.  **Configuration**: The `config.yaml` file, which is bundled with the function source code.
 2.  **Google Cloud Data**:
       * The list of projects, folders, and organizations obtained via the Cloud Resource Manager API.
-      * Cost data obtained from your billing export view in BigQuery.
+      * Cost data obtained from your billing export table in BigQuery.
 
 ### Outputs
 
@@ -209,7 +180,7 @@ Creates human-readable aliases for your numeric organization IDs.
       * Owner's name.
       * A list of problematic projects.
       * The project's age in days.
-      * The project's cost since the previous month.
+      * The project's cost within the configured time window.
 2.  **(Optional) JSON Dump File**: If the `dump_json_file_name` key is set in `config.yaml`, a JSON file with enriched project data will be saved locally when running in CLI mode.
 
 ## Local Development

--- a/billing.py
+++ b/billing.py
@@ -5,32 +5,49 @@ from google.cloud import bigquery
 logger = logging.getLogger(__name__)
 
 BIGQUERY_CLIENT_PROJECT = CONFIG['billing']['bigquery_client_project'].get()
-COST_VIEW_FULL_NAME = CONFIG['billing']['cost_view_full_name'].get()
+BILLING_TABLE_FULL_NAME = CONFIG['billing']['billing_export_table_name'].get()
+COST_WINDOW_DAYS = CONFIG['filters']['age_maximum_days'].get(int)
 
 def query_billing_info():
     client = bigquery.Client(project=BIGQUERY_CLIENT_PROJECT)
-    query_job = client.query("""
+
+    if COST_WINDOW_DAYS and COST_WINDOW_DAYS > 0:
+        date_filter_clause = f"AND PARSE_DATE('%Y-%m-%d', FORMAT_TIMESTAMP('%Y-%m-%d', usage_start_time)) >= DATE_SUB(CURRENT_DATE(), INTERVAL {COST_WINDOW_DAYS} DAY)"
+        cost_reference_date = f"DATE_SUB(CURRENT_DATE(), INTERVAL {COST_WINDOW_DAYS} DAY)"
+    else:
+        date_filter_clause = "AND PARSE_DATE('%Y-%m-%d', FORMAT_TIMESTAMP('%Y-%m-%d', usage_start_time)) >= DATE_SUB(DATE_TRUNC(CURRENT_DATE(), MONTH), INTERVAL 1 MONTH)"
+        cost_reference_date = "DATE_SUB(DATE_TRUNC(CURRENT_DATE(), MONTH), INTERVAL 1 MONTH)"
+
+    query = f"""
         SELECT
-            billing_account_name
-        ,   billing_account_id
-        ,   project_id
-        ,   cost_generated
-        ,   currency
-        ,   cost_reference_start_date
+            billing_account_id,
+            project.id AS project_id,
+            ROUND(SUM(cost), 2) AS cost_generated,
+            currency,
+            ({cost_reference_date}) AS cost_reference_start_date
         FROM
-            `{}`
+            `{BILLING_TABLE_FULL_NAME}`
+        WHERE
+            project.id IS NOT NULL
+            {date_filter_clause}
+        GROUP BY
+            billing_account_id,
+            project.id,
+            currency,
+            cost_reference_start_date
         ORDER BY
             cost_generated DESC
         LIMIT 1000
-    """.format(COST_VIEW_FULL_NAME))
+    """
 
-    logger.debug('Executing cost query.')
+    logger.debug('Executing dynamic cost query:\n%s', query)
+    query_job = client.query(query)
     results = query_job.result()
     
     results_by_project = {}
     for row in results:
         results_by_project[row.project_id] = {
-            'billingAccountName': row.billing_account_name,
+            'billingAccountName': row.billing_account_id,
             'billingAccountId': row.billing_account_id,
             'projectId': row.project_id,
             'costGenerated': row.cost_generated,
@@ -39,3 +56,4 @@ def query_billing_info():
         }
 
     return results_by_project
+

--- a/billing.py
+++ b/billing.py
@@ -11,7 +11,7 @@ COST_WINDOW_DAYS = CONFIG['filters']['age_maximum_days'].get(int)
 def query_billing_info():
     client = bigquery.Client(project=BIGQUERY_CLIENT_PROJECT)
 
-    if COST_WINDOW_DAYS and COST_WINDOW_DAYS > 0:
+    if COST_WINDOW_DAYS:
         date_filter_clause = f"AND PARSE_DATE('%Y-%m-%d', FORMAT_TIMESTAMP('%Y-%m-%d', usage_start_time)) >= DATE_SUB(CURRENT_DATE(), INTERVAL {COST_WINDOW_DAYS} DAY)"
         cost_reference_date = f"DATE_SUB(CURRENT_DATE(), INTERVAL {COST_WINDOW_DAYS} DAY)"
     else:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -6,6 +6,8 @@ filters:
     - '8888888888888'
   # Filter out projects created in less than X days.
   age_minimum_days: 5
+  # Filter out projects created in more than X days. Set to 0 to disable.
+  age_maximum_days: 180
   # Filter out projects if any owner matches with any regex listed.
   users_regex:
     - kieras@.*

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -76,9 +76,9 @@ billing:
   activate: false
   # Project BigQuery client use to connect to dataset.
   bigquery_client_project: my-project
-  # Full BigQuery view name with Billin export information.
-  # See example-bigquery-billing-costs-view.sql file for an example query.
-  cost_view_full_name: my-project.billing.cost_per_project_starting_from_last_month
+  # Full BigQuery table name with Billing export information.
+  # Format: project-id.dataset_name.gcp_billing_export_v1_XXXXXX_XXXXXX_XXXXXX
+  billing_export_table_name: my-project.billing.gcp_billing_export_v1_010101_010101_010101
 org_names_mapping:
   # Mapping to give meaningful names to organizations in messages.
   '9999999999999': my-org

--- a/filters.py
+++ b/filters.py
@@ -27,6 +27,14 @@ def filter_older_than(days):
             return False
     return filter_older_projects
 
+def filter_younger_than(days):
+    def filter_younger_projects(project):
+        if not days or int(project.get('createdDaysAgo')) < days:
+            return True
+        else:
+            return False
+    return filter_younger_projects
+
 
 def filter_owners(bindings):
     if bindings.get('role') == 'roles/owner':
@@ -50,3 +58,4 @@ def filter_whitelisted_users(whitelisted_users_regex):
                     return False
         return True
     return filter_users
+

--- a/filters.py
+++ b/filters.py
@@ -27,14 +27,6 @@ def filter_older_than(days):
             return False
     return filter_older_projects
 
-def filter_younger_than(days):
-    def filter_younger_projects(project):
-        if not days or int(project.get('createdDaysAgo')) < days:
-            return True
-        else:
-            return False
-    return filter_younger_projects
-
 
 def filter_owners(bindings):
     if bindings.get('role') == 'roles/owner':

--- a/main.py
+++ b/main.py
@@ -20,7 +20,6 @@ from utils import (
 from filters import (
     filter_projects_matching_org_level,
     filter_older_than,
-    filter_younger_than,
     filter_owners,
     filter_users,
     filter_whitelisted_projects,
@@ -35,7 +34,6 @@ ORGS_FILTER = CONFIG['filters']['orgs'].get()
 PROJECTS_FILTER = CONFIG['filters']['projects'].get() or []
 USERS_REGEX_FILTER = CONFIG['filters']['users_regex'].get() or []
 AGE_MINIMUM_DAYS_FILTER = CONFIG['filters']['age_minimum_days'].get(int)
-AGE_MAXIMUM_DAYS_FILTER = CONFIG['filters']['age_maximum_days'].get(int)
 SLACK_ACTIVATED = CONFIG['slack']['activate'].get(bool)
 CHAT_ACTIVATED = CONFIG['chat']['activate'].get(bool)
 BILLING_ACTIVATED = CONFIG['billing']['activate'].get(bool)
@@ -127,17 +125,10 @@ def main():
     if DEBUG_FILTERED_BY_AGE:
         logger.debug('Aged Projects filter applied:\n%s', pformat(older_projects))
         
-    logger.info('Filtering Projects by maximum age.')
-    age_filtered_projects = list(filter(filter_younger_than(
-        AGE_MAXIMUM_DAYS_FILTER), older_projects))
-
-    if DEBUG_FILTERED_BY_AGE:
-        logger.debug('Maximum age Projects filter applied:\n%s', pformat(age_filtered_projects))
-
     logger.info('Filtering Projects by org level.')
 
     org_projects = list(filter(filter_projects_matching_org_level(
-        ORGS_FILTER), age_filtered_projects))
+        ORGS_FILTER), older_projects))
 
     if DEBUG_FILTERED_BY_ORGS:
         logger.debug('Project by orgs:\n%s', pformat(org_projects))

--- a/main.py
+++ b/main.py
@@ -124,7 +124,6 @@ def main():
 
     if DEBUG_FILTERED_BY_AGE:
         logger.debug('Aged Projects filter applied:\n%s', pformat(older_projects))
-        
     logger.info('Filtering Projects by org level.')
 
     org_projects = list(filter(filter_projects_matching_org_level(

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from utils import (
 from filters import (
     filter_projects_matching_org_level,
     filter_older_than,
+    filter_younger_than,
     filter_owners,
     filter_users,
     filter_whitelisted_projects,
@@ -34,6 +35,7 @@ ORGS_FILTER = CONFIG['filters']['orgs'].get()
 PROJECTS_FILTER = CONFIG['filters']['projects'].get() or []
 USERS_REGEX_FILTER = CONFIG['filters']['users_regex'].get() or []
 AGE_MINIMUM_DAYS_FILTER = CONFIG['filters']['age_minimum_days'].get(int)
+AGE_MAXIMUM_DAYS_FILTER = CONFIG['filters']['age_maximum_days'].get(int)
 SLACK_ACTIVATED = CONFIG['slack']['activate'].get(bool)
 CHAT_ACTIVATED = CONFIG['chat']['activate'].get(bool)
 BILLING_ACTIVATED = CONFIG['billing']['activate'].get(bool)
@@ -124,11 +126,18 @@ def main():
 
     if DEBUG_FILTERED_BY_AGE:
         logger.debug('Aged Projects filter applied:\n%s', pformat(older_projects))
+        
+    logger.info('Filtering Projects by maximum age.')
+    age_filtered_projects = list(filter(filter_younger_than(
+        AGE_MAXIMUM_DAYS_FILTER), older_projects))
+
+    if DEBUG_FILTERED_BY_AGE:
+        logger.debug('Maximum age Projects filter applied:\n%s', pformat(age_filtered_projects))
 
     logger.info('Filtering Projects by org level.')
 
     org_projects = list(filter(filter_projects_matching_org_level(
-        ORGS_FILTER), older_projects))
+        ORGS_FILTER), age_filtered_projects))
 
     if DEBUG_FILTERED_BY_ORGS:
         logger.debug('Project by orgs:\n%s', pformat(org_projects))


### PR DESCRIPTION
This PR introduces a configurable time window for project analysis to prevent notifications for very old projects that are likely no longer relevant. By adding an `age_maximum_days` filter, the bot can now focus on a more specific timeframe (e.g., projects created between 5 and 180 days ago), making the alerts more actionable and reducing noise.